### PR TITLE
Bump bootstrap from 3.0.0 to 3.4.1

### DIFF
--- a/FAAH/packages.config
+++ b/FAAH/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="bootstrap" version="3.0.0" targetFramework="net461" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net461" />
   <package id="jQuery" version="1.10.2" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc.ja" version="5.2.3" targetFramework="net461" />


### PR DESCRIPTION
CVE-2019-8331

In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/